### PR TITLE
added skeleton for Related products list

### DIFF
--- a/client/dist/styles/styles.css
+++ b/client/dist/styles/styles.css
@@ -32,7 +32,3 @@ p, h1, h2, h3, h4, h5, h6 {
 #root, #__next {
   isolation: isolate;
 }
-
-
-
-

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -1,18 +1,15 @@
 import React from 'react';
 import Overview from './Overview';
 import QListContainer from '../containers/QListContainer';
-
-//NOTE: Should only have containers rendered inside, using QuestionList
-//component temporarily, will change either when done with CSS or when container is built
+import RelatedProducts from './RelatedProducts';
 
 function App() {
   return (
-    <div>
-      <div>
-        <Overview />
-        <QListContainer />
-      </div>
-    </div>
+    <>
+      <Overview />
+      <RelatedProducts />
+      <QListContainer />
+    </>
   );
 }
 

--- a/client/src/components/RelatedProductCard.jsx
+++ b/client/src/components/RelatedProductCard.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+/**
+ * Renders a card with information about a product
+ * 
+ * @param {props} product Product object retrieved from API to be rendered
+ * @returns list item containing product card
+ */
+function RelatedProductsComponent({ productName }) {
+  return (
+    <li>
+      {productName}
+    </li>
+  );
+}
+
+export default RelatedProductsComponent;

--- a/client/src/components/RelatedProducts.jsx
+++ b/client/src/components/RelatedProducts.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import Card from './RelatedProductCard';
+
+// Data is temporary obviously
+// TODO: collect products from API/redux store
+const related = [
+  'Shirt',
+  'Pant',
+  'scurf',
+];
+const outfit = [
+  'red shoes',
+  'yeezees',
+  'sick drip',
+];
+
+/**
+ * Renders two related product carrousels
+ * also provides semantic strucure for styling
+ */
+function RelatedProductsComponent() {
+  return (
+    <div id="related-items">
+      <ul className="product-carrousel">
+        {related.map((product) => <Card productName={product} />)}
+      </ul>
+      <ul className='product-carrousel'>
+        {outfit.map((product) => <Card productName={product} />)}
+      </ul>
+    </div>
+  );
+}
+
+export default RelatedProductsComponent;


### PR DESCRIPTION
Added 2 components, `RelatedProducts `and `RelatedProductCards`
Currently they both render some example data and don't make any API requests